### PR TITLE
.metaファイルの生成

### DIFF
--- a/Runtime/R3Extensions.meta
+++ b/Runtime/R3Extensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2acc6aca09c74504a84e21b80c75b3f0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/R3Extensions/StateVariableR3Extensions.cs.meta
+++ b/Runtime/R3Extensions/StateVariableR3Extensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fc74bac5b55e91f49b8db70988125777

--- a/Runtime/State.cs.meta
+++ b/Runtime/State.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d42d35c467628174d94f2d9d7a432851

--- a/Runtime/StateCollections.meta
+++ b/Runtime/StateCollections.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cb0e195095ef80b4a80f8c91eb796a72
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/StateCollections/IStateCollectionElementObserver.cs.meta
+++ b/Runtime/StateCollections/IStateCollectionElementObserver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0577c6649ecbc474d85aa75785c26688

--- a/Runtime/StateCollections/IStateCollectionElementReader.cs.meta
+++ b/Runtime/StateCollections/IStateCollectionElementReader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 55c3aaf85f1b3af48b4a67306a80700c

--- a/Runtime/StateCollections/IStateCollectionElementSetter.cs.meta
+++ b/Runtime/StateCollections/IStateCollectionElementSetter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fe2f0a38a7756ee439e88b6cc84f9ab8

--- a/Runtime/StateCollections/IStateCollectionModifier.cs.meta
+++ b/Runtime/StateCollections/IStateCollectionModifier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 70f3fce3e8c91bc48938b0fd93444f94

--- a/Runtime/StateCollections/IStateCollectionObserver.cs.meta
+++ b/Runtime/StateCollections/IStateCollectionObserver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7d4825e0e5c03ae45baabb99da6b3c85

--- a/Runtime/StateCollections/IStateCollectionReader.cs.meta
+++ b/Runtime/StateCollections/IStateCollectionReader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd3e5d682a632114da4fcaf3aedc13ed

--- a/Runtime/StateCollections/ObservableDictionaryState.cs.meta
+++ b/Runtime/StateCollections/ObservableDictionaryState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9409d5641483d4846889f10e0781b729

--- a/Runtime/StateCollections/ObservableListState.cs.meta
+++ b/Runtime/StateCollections/ObservableListState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8f7c3a5974356df44a9f653f9494536d

--- a/Runtime/States.meta
+++ b/Runtime/States.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 62ba5396b9894d54a9a8b4dff88c123e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/States/DependencyState.meta
+++ b/Runtime/States/DependencyState.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ebfc62680979f746b20ebd4368018c4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/States/DependencyState/DependencyState.cs.meta
+++ b/Runtime/States/DependencyState/DependencyState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f73bc724f6ac2d34aafbf1048d2cf4d3

--- a/Runtime/States/DependencyState/HalfDependencyState.cs.meta
+++ b/Runtime/States/DependencyState/HalfDependencyState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e6a4cca224d842e448c3eca996c563de

--- a/Runtime/States/IStateObserver.cs.meta
+++ b/Runtime/States/IStateObserver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3ac2ad78d340a4040ac1dfb6fa6311d8

--- a/Runtime/States/IStateReader.cs.meta
+++ b/Runtime/States/IStateReader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 31a3bd93cab9c11459872a812e0b16e2

--- a/Runtime/States/IStateSetter.cs.meta
+++ b/Runtime/States/IStateSetter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 271cbf6016f68ff48a5d6ca5153d03f2

--- a/Runtime/States/ObservableState.cs.meta
+++ b/Runtime/States/ObservableState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 29eef1940e639784b85ef76a6d9f19a3

--- a/Runtime/States/SubjectState.cs.meta
+++ b/Runtime/States/SubjectState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b49aadc3acb6cef41876455b58f7ba83


### PR DESCRIPTION
Runtimeフォルダ配下のファイルたちに、.metaがないものが多数あり、Unityに認識されない不具合がありました。
適当な.metaファイルを追加しました。